### PR TITLE
Add research section

### DIFF
--- a/src/app/research/[slug]/page.tsx
+++ b/src/app/research/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import { Container } from "@/components/Container";
+import { SingleProduct } from "@/components/Product";
+import { papers } from "@/constants/research";
+import { Paper } from "@/types/research";
+import { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+type Props = {
+  params: { slug: string };
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const paper = papers.find((p) => p.slug === params.slug);
+  if (paper) {
+    return {
+      title: paper.title,
+      description: paper.description,
+    };
+  }
+  return {
+    title: "Research | Tanish Patel",
+    description: "Research papers authored by Tanish Patel.",
+  };
+}
+
+export default function ResearchPage({ params }: { params: { slug: string } }) {
+  const paper = papers.find((p) => p.slug === params.slug);
+  if (!paper) {
+    redirect("/research");
+  }
+  return (
+    <Container>
+      {paper && <SingleProduct product={paper as any} />}
+    </Container>
+  );
+}

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -1,0 +1,19 @@
+import { Container } from "@/components/Container";
+import { Heading } from "@/components/Heading";
+import { Metadata } from "next";
+import { ResearchGrid } from "@/components/ResearchGrid";
+
+export const metadata: Metadata = {
+  title: "Research | Tanish Patel",
+  description: "Research papers authored by Tanish Patel.",
+};
+
+export default function ResearchPage() {
+  return (
+    <Container>
+      <span className="text-4xl">📚</span>
+      <Heading className="font-black mb-10">Research Papers</Heading>
+      <ResearchGrid />
+    </Container>
+  );
+}

--- a/src/components/ResearchGrid.tsx
+++ b/src/components/ResearchGrid.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { cn } from "../../lib/utils";
+import Link from "next/link";
+import { Paper } from "@/types/research";
+import { papers } from "@/constants/research";
+
+export function ResearchGrid() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4  relative z-10 py-10 max-w-7xl mx-auto">
+      {papers.map((paper, index) => (
+        <Link href={`/research/${paper.slug}`} key={paper.slug}>
+          <Feature {...paper} index={index} />
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+const Feature = ({
+  title,
+  description,
+  icon,
+  index,
+}: {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  index: number;
+}) => {
+  return (
+    <div
+      className={cn(
+        "flex flex-col lg:border-r  py-10 relative group/feature dark:border-neutral-800",
+        (index === 0 || index === 4) && "lg:border-l dark:border-neutral-800",
+        index < 4 && "lg:border-b dark:border-neutral-800"
+      )}
+    >
+      {index < 4 && (
+        <div className="opacity-0 group-hover/feature:opacity-100 transition duration-200 absolute inset-0 h-full w-full bg-gradient-to-t from-neutral-100 dark:from-neutral-800 to-transparent pointer-events-none" />
+      )}
+      {index >= 4 && (
+        <div className="opacity-0 group-hover/feature:opacity-100 transition duration-200 absolute inset-0 h-full w-full bg-gradient-to-b from-neutral-100 dark:from-neutral-800 to-transparent pointer-events-none" />
+      )}
+      <div className="mb-4 relative z-10 px-10 text-neutral-600 dark:text-neutral-400">
+        {icon}
+      </div>
+      <div className="text-lg font-bold mb-2 relative z-10 px-10">
+        <div className="absolute left-0 inset-y-0 h-6 group-hover/feature:h-8 w-1 rounded-tr-full rounded-br-full bg-neutral-300 dark:bg-neutral-700 group-hover/feature:bg-blue-500 transition-all duration-200 origin-center" />
+        <span className="group-hover/feature:translate-x-2 transition duration-200 inline-block text-neutral-800 dark:text-neutral-100">
+          {title}
+        </span>
+      </div>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300 max-w-xs relative z-10 px-10">
+        {description}
+      </p>
+    </div>
+  );
+};

--- a/src/components/ResearchGrid.tsx
+++ b/src/components/ResearchGrid.tsx
@@ -6,7 +6,7 @@ import { papers } from "@/constants/research";
 
 export function ResearchGrid() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4  relative z-10 py-10 max-w-7xl mx-auto">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 place-items-center relative z-10 py-10 max-w-7xl mx-auto">
       {papers.map((paper, index) => (
         <Link href={`/research/${paper.slug}`} key={paper.slug}>
           <Feature {...paper} index={index} />
@@ -29,30 +29,11 @@ const Feature = ({
 }) => {
   return (
     <div
-      className={cn(
-        "flex flex-col lg:border-r  py-10 relative group/feature dark:border-neutral-800",
-        (index === 0 || index === 4) && "lg:border-l dark:border-neutral-800",
-        index < 4 && "lg:border-b dark:border-neutral-800"
-      )}
+      className="w-72 h-60 bg-sky-50 dark:bg-neutral-900 border border-sky-200 dark:border-sky-800 rounded-lg flex flex-col p-6 hover:bg-sky-100 dark:hover:bg-neutral-800 transition"
     >
-      {index < 4 && (
-        <div className="opacity-0 group-hover/feature:opacity-100 transition duration-200 absolute inset-0 h-full w-full bg-gradient-to-t from-neutral-100 dark:from-neutral-800 to-transparent pointer-events-none" />
-      )}
-      {index >= 4 && (
-        <div className="opacity-0 group-hover/feature:opacity-100 transition duration-200 absolute inset-0 h-full w-full bg-gradient-to-b from-neutral-100 dark:from-neutral-800 to-transparent pointer-events-none" />
-      )}
-      <div className="mb-4 relative z-10 px-10 text-neutral-600 dark:text-neutral-400">
-        {icon}
-      </div>
-      <div className="text-lg font-bold mb-2 relative z-10 px-10">
-        <div className="absolute left-0 inset-y-0 h-6 group-hover/feature:h-8 w-1 rounded-tr-full rounded-br-full bg-neutral-300 dark:bg-neutral-700 group-hover/feature:bg-blue-500 transition-all duration-200 origin-center" />
-        <span className="group-hover/feature:translate-x-2 transition duration-200 inline-block text-neutral-800 dark:text-neutral-100">
-          {title}
-        </span>
-      </div>
-      <p className="text-sm text-neutral-600 dark:text-neutral-300 max-w-xs relative z-10 px-10">
-        {description}
-      </p>
+      <div className="mb-3 text-sky-600 dark:text-sky-400 text-3xl">{icon}</div>
+      <div className="text-lg font-bold mb-2 text-primary">{title}</div>
+      <p className="text-sm text-secondary overflow-y-auto">{description}</p>
     </div>
   );
 };

--- a/src/constants/navlinks.tsx
+++ b/src/constants/navlinks.tsx
@@ -2,6 +2,7 @@ import {
   IconArticle,
   IconBolt,
   IconBriefcase2,
+  IconBook,
   IconMail,
   IconMessage2,
 } from "@tabler/icons-react";
@@ -21,6 +22,11 @@ export const navlinks = [
     href: "/projects",
     label: "Projects",
     icon: IconBriefcase2,
+  },
+  {
+    href: "/research",
+    label: "Research",
+    icon: IconBook,
   },
   {
     href: "/blog",

--- a/src/constants/research.tsx
+++ b/src/constants/research.tsx
@@ -1,0 +1,53 @@
+import {
+  IconArticle,
+  IconBook,
+  IconFlask,
+  IconBrain,
+} from "@tabler/icons-react";
+import { Paper } from "@/types/research";
+
+export const papers: Paper[] = [
+  {
+    slug: "pmscania",
+    title: "Predictive Maintenance in SCANIA Trucks",
+    description:
+      "Mitigating failures by using Federated Learning and Explainable AI",
+    href: "https://drive.google.com/file/d/1ifI7p4PkfIVfg2vRjPw-sKFXm30l4Q8t/view?usp=drive_link",
+    thumbnail: "/images/diagram_minor.png",
+    images: ["/images/diagram_minor.png"],
+    icon: <IconFlask />,
+    content: (
+      <div>
+        <p>
+          Predictive maintenance is a vital approach in modern industries, enabling reduced downtime, optimized resources, and enhanced operational efficiency. This study develops a federated survival analysis framework augmented with explainable AI (XAI) to predict the Remaining Useful Life (RUL) of components and assess failure risks while preserving data privacy.
+        </p>
+        <p>
+          The framework leverages federated learning to aggregate insights from decentralized data across multiple clients. Three survival models—Random Survival Forest (RSF), Gradient Boosting Survival Analysis (GBSA), and Support Survival Vector Machines (SSVM)—were evaluated across 10 federated clients over 10 rounds. Model performance was assessed using the Concordance Index (C-index), where RSF outperformed the others with global training and testing C-index values of 0.7577 and 0.7376, respectively.
+        </p>
+        <p>
+          Explainability was achieved through SHAP, providing insights into feature contributions to model predictions. Key features were identified as critical predictors of survival outcomes. The RSF survivability plot demonstrated declining survival probabilities over time, enabling predictive maintenance planning.
+        </p>
+      </div>
+    ),
+  },
+  {
+    slug: "flsocpred",
+    title: "FL for State of Charge Prediction",
+    description:
+      "Data-Driven SoC Forecasting in Electric Vehicles: A Federated Learning Perspective",
+    href: "https://link.springer.com/book/9789819767939",
+    thumbnail: "/images/SOC_1.png",
+    images: ["/images/SOC_1.png", "/images/SOC_2.png"],
+    icon: <IconBrain />,
+    content: (
+      <div>
+        <p>
+          Electric Vehicles (EVs) are pivotal for sustainable transportation, but their widespread adoption is hindered by challenges in accurately estimating the State of Charge (SoC). This study explores federated learning to enhance SoC estimation in EVs.
+        </p>
+        <p>
+          Across multiple rounds of federated training, models showed consistent improvements in SoC prediction accuracy. Error metrics such as MSE and MAE decreased over time, demonstrating the effectiveness of the collaborative approach while maintaining data privacy.
+        </p>
+      </div>
+    ),
+  },
+];

--- a/src/types/research.tsx
+++ b/src/types/research.tsx
@@ -1,0 +1,11 @@
+export type Paper = {
+  slug: string;
+  title: string;
+  description: string;
+  href: string;
+  thumbnail: string;
+  images: string[];
+  icon: React.ReactNode;
+  stack?: string[];
+  content?: React.ReactNode;
+};


### PR DESCRIPTION
## Summary
- add Research link in sidebar navigation
- display research papers with ResearchGrid
- add research constants and types
- create research list and detail pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851360db58483249204dd3f0c134a75