### PR TITLE
Show disabled 'Learn More' tooltip when project link is missing

### DIFF
--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -71,29 +71,59 @@ export const SingleProduct = ({ product }: { product: Product }) => {
         {product?.content}
       </div>
 
-      <a
-        href={product.href}
-        target="__blank"
-        className="inline-flex items-center gap-1 group/button rounded-full hover:scale-105 focus:outline-none transition ring-offset-gray-900 bg-gray-800 text-white shadow-lg shadow-black/20 sm:backdrop-blur-sm group-hover/button:bg-gray-50/15 group-hover/button:scale-105 focus-visible:ring-1 focus-visible:ring-offset-2 ring-gray-50/60 text-sm font-medium px-4 py-2 mt-auto origin-left"
-      >
-        Learn More
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform"
+      {product.href ? (
+        <a
+          href={product.href}
+          target="__blank"
+          className="inline-flex items-center gap-1 group/button rounded-full hover:scale-105 focus:outline-none transition ring-offset-gray-900 bg-gray-800 text-white shadow-lg shadow-black/20 sm:backdrop-blur-sm group-hover/button:bg-gray-50/15 group-hover/button:scale-105 focus-visible:ring-1 focus-visible:ring-offset-2 ring-gray-50/60 text-sm font-medium px-4 py-2 mt-auto origin-left"
         >
-          <path d="M5 12l14 0"></path>
-          <path d="M13 18l6 -6"></path>
-          <path d="M13 6l6 6"></path>
-        </svg>
-      </a>
+          Learn More
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform"
+          >
+            <path d="M5 12l14 0"></path>
+            <path d="M13 18l6 -6"></path>
+            <path d="M13 6l6 6"></path>
+          </svg>
+        </a>
+      ) : (
+        <div className="relative group/tooltip mt-auto origin-left">
+          <div
+            className="inline-flex items-center gap-1 rounded-full focus:outline-none transition ring-offset-gray-900 bg-gray-800/60 text-white/70 shadow-lg shadow-black/20 text-sm font-medium px-4 py-2 cursor-not-allowed"
+            aria-disabled="true"
+          >
+            Learn More
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-3.5 h-3.5"
+            >
+              <path d="M5 12l14 0"></path>
+              <path d="M13 18l6 -6"></path>
+              <path d="M13 6l6 6"></path>
+            </svg>
+          </div>
+          <span className="pointer-events-none absolute left-0 top-full mt-2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-xs text-white opacity-0 shadow-md transition-opacity group-hover/tooltip:opacity-100">
+            Unavailable as of now
+          </span>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Provide clear feedback when a project has no external link by showing a disabled "Learn More" control with a hover tooltip stating it is unavailable.

### Description
- Updated `src/components/Product.tsx` to conditionally render a disabled button with a hover tooltip reading "Unavailable as of now" when `product.href` is falsy. 
- Kept the existing anchor behavior for products that do have an `href` and open in a new tab. 
- Changed SVG attributes to React conventions (`strokeWidth`, `strokeLinecap`, `strokeLinejoin`) to eliminate invalid DOM property warnings. 
- Implemented tooltip styling with Tailwind classes and added `aria-disabled="true"` for accessibility.

### Testing
- Started the dev server with `npm run dev` and Next.js compiled the app successfully. 
- Ran an automated Playwright smoke script that navigated to `/projects/prognosisappointment`, hovered the "Learn More" element, and captured a screenshot at `artifacts/projects-unavailable-tooltip.png`, which completed successfully. 
- No unit tests were changed or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697268f76cb883249ae1a0fd6e3453d1)