### PR TITLE
Fix chat text cutoff by fetching complete API response before rendering

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -45,7 +45,9 @@ export async function POST(req: Request) {
   const anthropic = new Anthropic({ apiKey });
 
   try {
-    const response = await anthropic.messages.create({
+    // Use streaming server-side to avoid SDK timeout on long requests,
+    // but collect the full response before returning to the client
+    const stream = anthropic.messages.stream({
       model: "claude-sonnet-4-20250514",
       max_tokens: 32000,
       thinking: {
@@ -59,13 +61,15 @@ export async function POST(req: Request) {
     let thinking = "";
     let text = "";
 
-    for (const block of response.content) {
-      if (block.type === "thinking") {
-        thinking += block.thinking;
-      } else if (block.type === "text") {
-        text += block.text;
-      }
-    }
+    stream.on("thinking", (delta) => {
+      thinking += delta;
+    });
+
+    stream.on("text", (delta) => {
+      text += delta;
+    });
+
+    await stream.finalMessage();
 
     return NextResponse.json({ thinking, text });
   } catch (err) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,5 +1,4 @@
 import Anthropic from "@anthropic-ai/sdk";
-import { NextResponse } from "next/server";
 import { SYSTEM_PROMPT } from "@/constants/system-prompt";
 
 interface ChatMessageInput {
@@ -11,9 +10,9 @@ interface ChatMessageInput {
 export async function POST(req: Request) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
-    return NextResponse.json(
-      { error: "API key not configured" },
-      { status: 500 }
+    return new Response(
+      JSON.stringify({ error: "API key not configured" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
     );
   }
 
@@ -21,17 +20,17 @@ export async function POST(req: Request) {
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json(
-      { error: "Invalid request body" },
-      { status: 400 }
+    return new Response(
+      JSON.stringify({ error: "Invalid request body" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
     );
   }
 
   const { messages } = body;
   if (!messages || !Array.isArray(messages)) {
-    return NextResponse.json(
-      { error: "Messages array is required" },
-      { status: 400 }
+    return new Response(
+      JSON.stringify({ error: "Messages array is required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
     );
   }
 
@@ -43,38 +42,70 @@ export async function POST(req: Request) {
   );
 
   const anthropic = new Anthropic({ apiKey });
+  const encoder = new TextEncoder();
 
-  try {
-    // Use streaming server-side to avoid SDK timeout on long requests,
-    // but collect the full response before returning to the client
-    const stream = anthropic.messages.stream({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 32000,
-      thinking: {
-        type: "enabled",
-        budget_tokens: 10000,
-      },
-      system: SYSTEM_PROMPT,
-      messages: formattedMessages,
-    });
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        const response = anthropic.messages.stream({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 32000,
+          thinking: {
+            type: "enabled",
+            budget_tokens: 10000,
+          },
+          system: SYSTEM_PROMPT,
+          messages: formattedMessages,
+        });
 
-    let thinking = "";
-    let text = "";
+        response.on("thinking", (thinkingDelta) => {
+          const payload = JSON.stringify({
+            type: "thinking",
+            content: thinkingDelta,
+          });
+          controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+        });
 
-    stream.on("thinking", (delta) => {
-      thinking += delta;
-    });
+        response.on("text", (textDelta) => {
+          const payload = JSON.stringify({
+            type: "text",
+            content: textDelta,
+          });
+          controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+        });
 
-    stream.on("text", (delta) => {
-      text += delta;
-    });
+        response.on("end", () => {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify({ type: "done" })}\n\n`)
+          );
+          controller.close();
+        });
 
-    await stream.finalMessage();
+        response.on("error", (err: Error) => {
+          const payload = JSON.stringify({
+            type: "error",
+            content: err.message,
+          });
+          controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+          controller.close();
+        });
 
-    return NextResponse.json({ thinking, text });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Failed to get response";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+        await response.finalMessage();
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to get response";
+        const payload = JSON.stringify({ type: "error", content: message });
+        controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { NextResponse } from "next/server";
 import { SYSTEM_PROMPT } from "@/constants/system-prompt";
 
 interface ChatMessageInput {
@@ -10,9 +11,9 @@ interface ChatMessageInput {
 export async function POST(req: Request) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
-    return new Response(
-      JSON.stringify({ error: "API key not configured" }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
+    return NextResponse.json(
+      { error: "API key not configured" },
+      { status: 500 }
     );
   }
 
@@ -20,17 +21,17 @@ export async function POST(req: Request) {
   try {
     body = await req.json();
   } catch {
-    return new Response(
-      JSON.stringify({ error: "Invalid request body" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
     );
   }
 
   const { messages } = body;
   if (!messages || !Array.isArray(messages)) {
-    return new Response(
-      JSON.stringify({ error: "Messages array is required" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
+    return NextResponse.json(
+      { error: "Messages array is required" },
+      { status: 400 }
     );
   }
 
@@ -42,84 +43,34 @@ export async function POST(req: Request) {
   );
 
   const anthropic = new Anthropic({ apiKey });
-  const encoder = new TextEncoder();
 
-  const stream = new ReadableStream({
-    async start(controller) {
-      try {
-        const response = anthropic.messages.stream({
-          model: "claude-sonnet-4-20250514",
-          max_tokens: 32000,
-          thinking: {
-            type: "enabled",
-            budget_tokens: 10000,
-          },
-          system: SYSTEM_PROMPT,
-          messages: formattedMessages,
-        });
+  try {
+    const response = await anthropic.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 32000,
+      thinking: {
+        type: "enabled",
+        budget_tokens: 10000,
+      },
+      system: SYSTEM_PROMPT,
+      messages: formattedMessages,
+    });
 
-        response.on("thinking", (thinkingDelta) => {
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({
-                type: "thinking",
-                content: thinkingDelta,
-              })}\n\n`
-            )
-          );
-        });
+    let thinking = "";
+    let text = "";
 
-        response.on("text", (textDelta) => {
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({
-                type: "text",
-                content: textDelta,
-              })}\n\n`
-            )
-          );
-        });
-
-        response.on("end", () => {
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ type: "done" })}\n\n`
-            )
-          );
-          controller.close();
-        });
-
-        response.on("error", (err: Error) => {
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({
-                type: "error",
-                content: err.message,
-              })}\n\n`
-            )
-          );
-          controller.close();
-        });
-
-        await response.finalMessage();
-      } catch (err) {
-        const message =
-          err instanceof Error ? err.message : "Failed to get response";
-        controller.enqueue(
-          encoder.encode(
-            `data: ${JSON.stringify({ type: "error", content: message })}\n\n`
-          )
-        );
-        controller.close();
+    for (const block of response.content) {
+      if (block.type === "thinking") {
+        thinking += block.thinking;
+      } else if (block.type === "text") {
+        text += block.text;
       }
-    },
-  });
+    }
 
-  return new Response(stream, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    },
-  });
+    return NextResponse.json({ thinking, text });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to get response";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -93,8 +93,7 @@ export function ChatInterface() {
           }
 
           const jsonStr = line.slice(6);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let event: any;
+          let event: { type: string; content?: string };
           try {
             event = JSON.parse(jsonStr);
           } catch {

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -27,38 +27,6 @@ export function ChatInterface() {
     scrollToBottom();
   }, [messages, scrollToBottom]);
 
-  const streamText = useCallback(
-    (
-      fullText: string,
-      field: "content" | "thinking",
-      chunkSize: number,
-      intervalMs: number
-    ): Promise<void> => {
-      return new Promise((resolve) => {
-        let i = 0;
-        const timer = setInterval(() => {
-          if (i >= fullText.length) {
-            clearInterval(timer);
-            resolve();
-            return;
-          }
-          const end = Math.min(i + chunkSize, fullText.length);
-          const chunk = fullText.slice(i, end);
-          i = end;
-          setMessages((prev) => {
-            const updated = [...prev];
-            const last = updated[updated.length - 1];
-            if (last.role === "assistant") {
-              last[field] = (last[field] || "") + chunk;
-            }
-            return updated;
-          });
-        }, intervalMs);
-      });
-    },
-    []
-  );
-
   const sendMessage = async (content: string) => {
     setError(null);
 
@@ -99,24 +67,111 @@ export function ChatInterface() {
         );
       }
 
-      const data = await response.json();
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error("No response stream");
 
-      if (data.error) {
-        throw new Error(data.error);
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process all complete SSE messages (delimited by \n\n)
+        let boundary = buffer.indexOf("\n\n");
+        while (boundary !== -1) {
+          const rawLine = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+
+          // Extract JSON after "data: " prefix
+          const line = rawLine.trim();
+          if (!line.startsWith("data: ")) {
+            boundary = buffer.indexOf("\n\n");
+            continue;
+          }
+
+          const jsonStr = line.slice(6);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let event: any;
+          try {
+            event = JSON.parse(jsonStr);
+          } catch {
+            // Incomplete JSON — put it back and wait for more data
+            buffer = rawLine + "\n\n" + buffer;
+            break;
+          }
+
+          if (event.type === "thinking") {
+            setMessages((prev) => {
+              const updated = [...prev];
+              const last = updated[updated.length - 1];
+              if (last.role === "assistant") {
+                last.thinking = (last.thinking || "") + event.content;
+              }
+              return updated;
+            });
+          } else if (event.type === "text") {
+            setMessages((prev) => {
+              const updated = [...prev];
+              const last = updated[updated.length - 1];
+              if (last.role === "assistant") {
+                last.content = (last.content || "") + event.content;
+              }
+              return updated;
+            });
+          } else if (event.type === "done") {
+            setMessages((prev) => {
+              const updated = [...prev];
+              const last = updated[updated.length - 1];
+              if (last.role === "assistant") {
+                last.isStreaming = false;
+              }
+              return updated;
+            });
+          } else if (event.type === "error") {
+            throw new Error(event.content);
+          }
+
+          boundary = buffer.indexOf("\n\n");
+        }
       }
 
-      // Stream thinking first, then text — simulated for smooth UX
-      if (data.thinking) {
-        await streamText(data.thinking, "thinking", 20, 5);
-      }
-      if (data.text) {
-        await streamText(data.text, "content", 3, 10);
+      // Process any remaining complete message in the buffer
+      const remaining = buffer.trim();
+      if (remaining.startsWith("data: ")) {
+        try {
+          const event = JSON.parse(remaining.slice(6));
+          if (event.type === "text") {
+            setMessages((prev) => {
+              const updated = [...prev];
+              const last = updated[updated.length - 1];
+              if (last.role === "assistant") {
+                last.content = (last.content || "") + event.content;
+              }
+              return updated;
+            });
+          } else if (event.type === "thinking") {
+            setMessages((prev) => {
+              const updated = [...prev];
+              const last = updated[updated.length - 1];
+              if (last.role === "assistant") {
+                last.thinking = (last.thinking || "") + event.content;
+              }
+              return updated;
+            });
+          }
+        } catch {
+          // Ignore incomplete trailing data
+        }
       }
 
+      // Ensure streaming flag is always cleared
       setMessages((prev) => {
         const updated = [...prev];
         const last = updated[updated.length - 1];
-        if (last.role === "assistant") {
+        if (last.role === "assistant" && last.isStreaming) {
           last.isStreaming = false;
         }
         return updated;

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -27,52 +27,37 @@ export function ChatInterface() {
     scrollToBottom();
   }, [messages, scrollToBottom]);
 
-  const processSSELine = (line: string) => {
-    const dataMatch = line.match(/^data: (.+)$/s);
-    if (!dataMatch) return;
-
-    try {
-      const event = JSON.parse(dataMatch[1]);
-
-      if (event.type === "thinking") {
-        setMessages((prev) => {
-          const updated = [...prev];
-          const last = updated[updated.length - 1];
-          if (last.role === "assistant") {
-            last.thinking = (last.thinking || "") + event.content;
+  const streamText = useCallback(
+    (
+      fullText: string,
+      field: "content" | "thinking",
+      chunkSize: number,
+      intervalMs: number
+    ): Promise<void> => {
+      return new Promise((resolve) => {
+        let i = 0;
+        const timer = setInterval(() => {
+          if (i >= fullText.length) {
+            clearInterval(timer);
+            resolve();
+            return;
           }
-          return updated;
-        });
-      } else if (event.type === "text") {
-        setMessages((prev) => {
-          const updated = [...prev];
-          const last = updated[updated.length - 1];
-          if (last.role === "assistant") {
-            last.content = (last.content || "") + event.content;
-          }
-          return updated;
-        });
-      } else if (event.type === "done") {
-        setMessages((prev) => {
-          const updated = [...prev];
-          const last = updated[updated.length - 1];
-          if (last.role === "assistant") {
-            last.isStreaming = false;
-          }
-          return updated;
-        });
-      } else if (event.type === "error") {
-        throw new Error(event.content);
-      }
-    } catch (parseErr) {
-      if (
-        parseErr instanceof Error &&
-        parseErr.message !== "Unexpected end of JSON input"
-      ) {
-        throw parseErr;
-      }
-    }
-  };
+          const end = Math.min(i + chunkSize, fullText.length);
+          const chunk = fullText.slice(i, end);
+          i = end;
+          setMessages((prev) => {
+            const updated = [...prev];
+            const last = updated[updated.length - 1];
+            if (last.role === "assistant") {
+              last[field] = (last[field] || "") + chunk;
+            }
+            return updated;
+          });
+        }, intervalMs);
+      });
+    },
+    []
+  );
 
   const sendMessage = async (content: string) => {
     setError(null);
@@ -95,7 +80,6 @@ export function ChatInterface() {
     setIsLoading(true);
 
     try {
-      // Include thinking in history for conversation context awareness
       const allMessages = [...messages, userMessage].map((m) => ({
         role: m.role,
         content: m.content,
@@ -115,35 +99,24 @@ export function ChatInterface() {
         );
       }
 
-      const reader = response.body?.getReader();
-      if (!reader) throw new Error("No response stream");
+      const data = await response.json();
 
-      const decoder = new TextDecoder();
-      let buffer = "";
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          processSSELine(line);
-        }
+      if (data.error) {
+        throw new Error(data.error);
       }
 
-      // Process any remaining data in the buffer after stream ends
-      if (buffer.trim()) {
-        processSSELine(buffer.trim());
+      // Stream thinking first, then text — simulated for smooth UX
+      if (data.thinking) {
+        await streamText(data.thinking, "thinking", 20, 5);
+      }
+      if (data.text) {
+        await streamText(data.text, "content", 3, 10);
       }
 
-      // Ensure streaming flag is cleared even if no "done" event was received
       setMessages((prev) => {
         const updated = [...prev];
         const last = updated[updated.length - 1];
-        if (last.role === "assistant" && last.isStreaming) {
+        if (last.role === "assistant") {
           last.isStreaming = false;
         }
         return updated;


### PR DESCRIPTION
Replaced SSE streaming with a non-streaming API call that collects the full response server-side, then simulates a typing effect client-side. This prevents text from being cut off midway due to dropped stream chunks.